### PR TITLE
:sparkles: Support resx name as PO msgid & fix publish profile for .NET 8

### DIFF
--- a/tools/POTools/Commands/ExtractCommand.cs
+++ b/tools/POTools/Commands/ExtractCommand.cs
@@ -44,6 +44,9 @@ internal class ExtractCommand : ICommand
     [Option("-m|--merge", Description = "Merge newly extracted entries into the previously created catalog if exists. Applies only when output file path is specified.")]
     public bool Merge { get; set; }
 
+    [Option("--use-resx-name", Description = "Use RESX name as id instead of value. Applies only when a .resx file is specified.")]
+    public bool UseResxName { get; set; }
+
     [Option("--no-backup", Description = "Don't backup existing output files.")]
     public bool NoBackup { get; set; }
 
@@ -85,6 +88,8 @@ internal class ExtractCommand : ICommand
         var extractor = data.GetExtractor(extension);
         if (extractor == null)
             return data;
+        if (extractor is ResourceTextExtractor && UseResxName)
+            extractor = new ResourceNameTextExtractor();
 
         string content;
         LocalizableTextInfo[] texts;
@@ -178,7 +183,7 @@ internal class ExtractCommand : ICommand
 
                     entry =
                         key.PluralId == null ?
-                        (IPOEntry)new POSingularEntry(key) { Translation = key.Id } :
+                        (IPOEntry)new POSingularEntry(key) { Translation = text.Translation ?? key.Id } :
                         new POPluralEntry(key) { key.Id, key.PluralId };
 
                     entry.Comments = new List<POComment>();

--- a/tools/POTools/POTools.csproj
+++ b/tools/POTools/POTools.csproj
@@ -9,7 +9,9 @@
     <ToolCommandName>dotnet-po</ToolCommandName>
     <PackageOutputPath>..\..\.nuget</PackageOutputPath>
   </PropertyGroup>
-
+  <ItemGroup>
+    <TrimmerRootAssembly Include="POTools" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Buildalyzer" Version="7.0.1" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />

--- a/tools/POTools/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/tools/POTools/Properties/PublishProfiles/FolderProfile.pubxml
@@ -6,10 +6,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <Configuration>Release</Configuration>
     <Platform>Any CPU</Platform>
-    <PublishDir>bin\Release\net6.0\publish\win-x64\</PublishDir>
+    <PublishDir>bin\Release\net8.0\publish\win-x64\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
     <_TargetId>Folder</_TargetId>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>true</PublishSingleFile>

--- a/tools/POTools/Services/Extracting/LocalizableTextInfo.cs
+++ b/tools/POTools/Services/Extracting/LocalizableTextInfo.cs
@@ -6,5 +6,6 @@ public class LocalizableTextInfo
     public string Id { get; set; } = null!;
     public string? PluralId { get; set; }
     public string? ContextId { get; set; }
+    public string? Translation { get; set; }
     public string? ExtractedComment { get; set; }
 }

--- a/tools/POTools/Services/Extracting/ResourceNameTextExtractor.cs
+++ b/tools/POTools/Services/Extracting/ResourceNameTextExtractor.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using POTools.Services.Resources;
+
+namespace POTools.Services.Extracting;
+
+public class ResourceNameTextExtractor : ILocalizableTextExtractor
+{
+    public IEnumerable<LocalizableTextInfo> Extract(string content, CancellationToken cancellationToken = default)
+    {
+        ResXFileReader resourceReader;
+        using (var reader = new StringReader(content))
+            resourceReader = new ResXFileReader(reader);
+
+        // Select name, value, and comment from the resource reader.
+        return resourceReader.Select(item => new LocalizableTextInfo
+        {
+            Id = item.Name,
+            Translation = item.Value.Replace("\n", Environment.NewLine),
+            ExtractedComment = $"{(item.Comment.Length > 0 ? item.Comment + " " : string.Empty)}[{item.Name}]",
+        });
+    }
+}


### PR DESCRIPTION
Hi!

This is a minor addition that adds a -n or --name switch to POTools, making it use the RESX 'Name' attribute instead of 'Value' for the PO msgid. The reason being that when using it to extract PO/POT files from a RESX file, it get's a bit unwieldly with the default of using the original text as the msgid. The RESX 'Name' tends to change much less frequently, even if the actual text is tweaked, so this makes it much easier to maintain translations when using an external translation tool or service, since a change to an existing source text will not be treated as a delete/add, but as a change.

Also, I updated the publish profile to .NET 8 since the project has been updated (great, thanks!). This also necessitated add the POTools assembly as a root assembly for trimming since otherwise the command line parser breaks...

I tried to keep the changes to a minimum, conform to the coding style etc. This did make a few of the changes less than pretty, but I did not want to change any fundamentals, or method signatures etc. Still I think it's pretty clear what's going on, and as far as I can tell it's a pure addition and should not cause any compatibility problems with the previous version.